### PR TITLE
Add iced_tutorial

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ A curated list of custom widgets, resources, integrations, and projects made wit
 - <img src="https://img.shields.io/badge/0.4-blue?logo=iced&style=plastic">&ensp;[GUIs in Rust with iced (An on-going series).](https://nikolish.in/gs-with-iced-1)
 - <img src="https://img.shields.io/badge/0.4-blue?logo=iced&style=plastic">&ensp;[Build a simple frontend web app.](https://blog.logrocket.com/iced-rs-tutorial-rust-frontend-web-app/)
 - [How to use custom themes in iced (video tutorial).](https://www.youtube.com/watch?v=Bl02RY3FXJU)
+- <img src="https://img.shields.io/badge/0.10-blue?logo=iced&style=plastic">&ensp;[An unofficial tutorial.](https://github.com/fogarecious/iced_tutorial/blob/main/README.md)
 
 <!-- END CONTENT -->
 


### PR DESCRIPTION
This PR adds a link to iced_tutorial.

While the current tutorials mainly target Iced version 0.4, this one pertains to version 0.10. Furthermore, it encompasses a broader range of topics.