### PR TITLE
Add shadcn-rs to Custom Widgets section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ A curated list of custom widgets, resources, integrations, and projects made wit
 - <img src="https://img.shields.io/badge/0.13-blue?logo=iced&style=plastic"> &ensp;[iced_term](https://github.com/Harzu/iced_term) - Terminal emulator widget powered by ICED framework and alacritty terminal backend.
 - <img src="https://img.shields.io/badge/master-blue?logo=iced&style=plastic"> &ensp;[frozen_term](https://github.com/Rahn-IT/frostbyte_terminal/tree/master/frozen_term) - Terminal emulator component based on wezterm and combatible with any datastream.
 - <img src="https://img.shields.io/badge/master-blue?logo=iced&style=plastic"> &ensp;[iced_code_editor](https://github.com/LuDog71FR/iced-code-editor) - A fully-featured code editor widget with syntax highlighting, line numbers, text selection, and comprehensive keyboard navigation.
+- <img src="https://img.shields.io/badge/0.14-blue?logo=iced&style=plastic"> &ensp;[shadcn-rs](https://github.com/FerrisMind/shadcn-rs) - Shadcn-inspired component kit for iced.
 
 ## Resources
 


### PR DESCRIPTION
Added shadcn-rs to the Custom Widgets section. It is a Shadcn-inspired component kit for Iced (and Egui).

- [x] Follows the required format:  - [item name](link) - Description.
- [x] Added to the bottom of the section.
- [x] Checked spelling and grammar.